### PR TITLE
cannot import name 'ENVIRON'

### DIFF
--- a/pyhanlp/__init__.py
+++ b/pyhanlp/__init__.py
@@ -174,3 +174,4 @@ class LazyLoadingJClass(object):
 CustomDictionary = LazyLoadingJClass('com.hankcs.hanlp.dictionary.CustomDictionary')
 HanLP = SafeJClass('com.hankcs.hanlp.HanLP')
 PerceptronLexicalAnalyzer = SafeJClass('com.hankcs.hanlp.model.perceptron.PerceptronLexicalAnalyzer')
+ENVIRON = os.environ.copy()


### PR DESCRIPTION
cannot import name 'ENVIRON' , Python 新手，暂时添加了一行解决import错误。