### PR TITLE
fix the root path at hanlp.properties

### DIFF
--- a/pyhanlp/static/__init__.py
+++ b/pyhanlp/static/__init__.py
@@ -279,6 +279,7 @@ def read_config():
     root = None
     if not os.path.isfile(PATH_CONFIG):
         copyfile(PATH_CONFIG + '.in', PATH_CONFIG)
+        write_config(root=STATIC_ROOT)
     with open_(PATH_CONFIG, encoding='utf-8') as f:
         for line in f:
             if line.startswith('root'):


### PR DESCRIPTION
Once the hanlp.properties are deleted, 
the model only copy new hanlp.properties from hanlp.properties.in, 
however the root path still is none (at  hanlp.properties.in),
It should be write_config for add the root path.
