### PR TITLE
修正pyhanlp-0.1.57 windows 无法自动下载 data 文件的问题

### DIFF
--- a/pyhanlp/static/__init__.py
+++ b/pyhanlp/static/__init__.py
@@ -270,7 +270,7 @@ def read_config():
         for line in f:
             if line.startswith('root'):
                 root = line.strip().split('=')[1]
-    return root
+    return os.path.abspath(root)
 
 
 def hanlp_jar_path(version):


### PR DESCRIPTION
### 存在的BUG
由于 `read_config()` 读取配置得到的文件路径是 Unix 的文件路径 `/usr/xx`, 而 `STATIC_ROOT` 是 Python 自动处理得到的 Windows 的文件路径 `C:\\Users\\xxx`, 这导致在 `hanlp_installed_data_path()` 函数中的 `root == STATIC_ROOT`, 不管是不是为同一路径，结果都是 `False`, 从而导致 Windows 下不会自动下载 data 数据文件

### 解决方法
`read_config()` 中返回 `os.path.abspath(root)`, 这样可以保证不同操作系统下的**文件路径格式一致**。
