### PR TITLE
修正ssl验证导致某些环境中无法自动下载的问题

### DIFF
--- a/pyhanlp/static/__init__.py
+++ b/pyhanlp/static/__init__.py
@@ -7,12 +7,14 @@ from __future__ import print_function
 import os
 import platform
 import shutil
+import ssl
 import sys
 
 from pyhanlp.util import eprint, browser_open
 
 curdir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(curdir, os.path.pardir))
+ssl._create_default_https_context = ssl._create_unverified_context
 
 PY = 3
 if sys.version_info[0] < 3:


### PR DESCRIPTION
我在mac上
Python 3.7.3 (default, Nov 15 2019, 04:04:52)
[Clang 11.0.0 (clang-1100.0.33.16)] on darwin
遇到了这个问题