### PR TITLE
add envrion classpath for start JVM

### DIFF
--- a/pyhanlp/__init__.py
+++ b/pyhanlp/__init__.py
@@ -118,6 +118,8 @@ def _start_jvm_for_hanlp():
                 PATH_CONFIG = PATH_CONFIG.replace(cygwin_driver, win_driver)
     JAVA_JAR_CLASSPATH = "-Djava.class.path=%s%s%s" % (
         HANLP_JAR_PATH, pathsep, STATIC_ROOT)
+    if ENVIRON["CLASSPATH"]:
+        JAVA_JAR_CLASSPATH = JAVA_JAR_CLASSPATH + pathsep + ENVIRON["CLASSPATH"]
     # 加载插件jar
     for jar in glob.glob(os.path.join(STATIC_ROOT, '*.jar')):
         if HANLP_JAR_PATH.endswith(jar):

--- a/pyhanlp/__init__.py
+++ b/pyhanlp/__init__.py
@@ -118,7 +118,7 @@ def _start_jvm_for_hanlp():
                 PATH_CONFIG = PATH_CONFIG.replace(cygwin_driver, win_driver)
     JAVA_JAR_CLASSPATH = "-Djava.class.path=%s%s%s" % (
         HANLP_JAR_PATH, pathsep, STATIC_ROOT)
-    if ENVIRON["CLASSPATH"]:
+    if ENVIRON.get("CLASSPATH", None):
         JAVA_JAR_CLASSPATH = JAVA_JAR_CLASSPATH + pathsep + ENVIRON["CLASSPATH"]
     # 加载插件jar
     for jar in glob.glob(os.path.join(STATIC_ROOT, '*.jar')):


### PR DESCRIPTION
For now, the default JVM which was started by `pyhanlp` ignores the environment variable`$CLASSPATH`.

https://github.com/hankcs/pyhanlp/blob/c200ab6760b9f626d2680f2e722a9098d58ebb2b/pyhanlp/__init__.py#L119-L134

If there have some other packages(such as PyArrow) that need to use JVM to load a class contained by jars which location in `CLASSPATH`, it may raise some errors.

---

Some code snippets in my scenario.
```python
import pyhanlp # it starts a JVM
import pyarrow as pa

# It will use hadoop-common.jar to create a connection to hdfs cluster
# Breaks down here, because it cannot find the jar
hfs = pa.hdfs.HadoopFileSystem() 
```

